### PR TITLE
fixup color tests

### DIFF
--- a/bin/process_results.py
+++ b/bin/process_results.py
@@ -25,7 +25,7 @@ def truncate(text, maxlength=500):
 
 def process_results(filepath):
     output = {"version": 2, "status": "pass", "message": None, "tests": []}
-    pattern = r"(?m)^((?P<file>.*test_.*\.c):\d+:(?P<name>\w+):(?P<status>PASS|FAIL)(?:: (?P<message>.*))?)$"
+    pattern = r"(?m)^((?P<file>.*test_.*\.c):\d+:(?P<name>\w+):(?:\033\[\d+m)?(?P<status>PASS|FAIL)(?:\033\[\d+m)?(?:: (?P<message>.*))?)$"
     text = filepath.read_text()
     # remove text "Compiling tests.out"
     text = text[20:]

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -30,6 +30,8 @@ tests_file="test_${exercise}.c"
 tests_file_original="${tests_file}.original"
 results_file="${output_dir}/results.json"
 output_file="${output_dir}/results.out"
+makefile="makefile"
+makefile_original="makefile.original"
 
 # Create the output directory if it doesn't exist
 mkdir -p "${output_dir}"
@@ -39,7 +41,10 @@ echo "${slug}: testing..."
 cd "${input_dir}" > /dev/null
 
 cp "${tests_file}" "${tests_file_original}"
+cp "${makefile}" "${makefile_original}"
 sed -i '/TEST_IGNORE\(\)/d' "${tests_file}"
+# tests need to be black and white for our python tooling
+sed -i 's/ -DUNITY_OUTPUT_COLOR//' "${makefile}"
 
 make clean
 stdbuf -oL make > "${output_file}" 2>&1
@@ -47,6 +52,7 @@ python3 "${process_results_file}" "${output_file}"
 
 # Restore the original file
 mv -f "${tests_file_original}" "${tests_file}"
+mv -f "${makefile_original}" "${makefile}"
 
 cd - > /dev/null
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -30,8 +30,6 @@ tests_file="test_${exercise}.c"
 tests_file_original="${tests_file}.original"
 results_file="${output_dir}/results.json"
 output_file="${output_dir}/results.out"
-makefile="makefile"
-makefile_original="makefile.original"
 
 # Create the output directory if it doesn't exist
 mkdir -p "${output_dir}"
@@ -43,8 +41,6 @@ cd "${input_dir}" > /dev/null
 cp "${tests_file}" "${tests_file_original}"
 cp "${makefile}" "${makefile_original}"
 sed -i '/TEST_IGNORE\(\)/d' "${tests_file}"
-# tests need to be black and white for our python tooling
-sed -i 's/ -DUNITY_OUTPUT_COLOR//' "${makefile}"
 
 make clean
 stdbuf -oL make > "${output_file}" 2>&1
@@ -52,7 +48,6 @@ python3 "${process_results_file}" "${output_file}"
 
 # Restore the original file
 mv -f "${tests_file_original}" "${tests_file}"
-mv -f "${makefile_original}" "${makefile}"
 
 cd - > /dev/null
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -39,7 +39,6 @@ echo "${slug}: testing..."
 cd "${input_dir}" > /dev/null
 
 cp "${tests_file}" "${tests_file_original}"
-cp "${makefile}" "${makefile_original}"
 sed -i '/TEST_IGNORE\(\)/d' "${tests_file}"
 
 make clean

--- a/tests/compile-error/makefile
+++ b/tests/compile-error/makefile
@@ -11,7 +11,7 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 CFLAGS += -Wmissing-declarations
-CFLAGS += -DUNITY_SUPPORT_64
+CFLAGS += -DUNITY_SUPPORT_64  -DUNITY_OUTPUT_COLOR
 
 ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common

--- a/tests/multiple-tests-with-all-passes/makefile
+++ b/tests/multiple-tests-with-all-passes/makefile
@@ -11,7 +11,7 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 CFLAGS += -Wmissing-declarations
-CFLAGS += -DUNITY_SUPPORT_64
+CFLAGS += -DUNITY_SUPPORT_64 -DUNITY_OUTPUT_COLOR
 
 ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common

--- a/tests/single-test-that-fails/makefile
+++ b/tests/single-test-that-fails/makefile
@@ -11,7 +11,7 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 CFLAGS += -Wmissing-declarations
-CFLAGS += -DUNITY_SUPPORT_64
+CFLAGS += -DUNITY_SUPPORT_64  -DUNITY_OUTPUT_COLOR
 
 ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common

--- a/tests/single-test-that-passes/makefile
+++ b/tests/single-test-that-passes/makefile
@@ -11,7 +11,7 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 CFLAGS += -Wmissing-declarations
-CFLAGS += -DUNITY_SUPPORT_64
+CFLAGS += -DUNITY_SUPPORT_64 -DUNITY_OUTPUT_COLOR
 
 ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common

--- a/tests/single-test-that-segfaults/makefile
+++ b/tests/single-test-that-segfaults/makefile
@@ -11,7 +11,7 @@ CFLAGS += -Wextra
 CFLAGS += -pedantic
 CFLAGS += -Werror
 CFLAGS += -Wmissing-declarations
-CFLAGS += -DUNITY_SUPPORT_64
+CFLAGS += -DUNITY_SUPPORT_64 -DUNITY_OUTPUT_COLOR
 
 ASANFLAGS  = -fsanitize=address
 ASANFLAGS += -fno-common


### PR DESCRIPTION
Updating the Python helper to detect ANSI test results without taking any issue with them.

This changes several (but not all) of the testing makefiles to make sure it works both ways.